### PR TITLE
Fixed passing config by object

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -17,6 +17,7 @@ var util = require('util');
 var defaultConfig = require(path.resolve(__dirname, 'motion_conf.json'));
 
 var Config = function(config) {
+  this.config = {};
   this.tmpFile = tmp.fileSync({ mode: '0644', prefix: 'motion-conf-', postfix: '.conf', keep: true});
   this.tmpFileName = this.tmpFile.name;
   if (typeof config === 'object') {


### PR DESCRIPTION
I use your project to start "motion" with a dynamic configuration, which is working fine, beside one issue:

Here is some dummy code:

```
var motionConfig  = require('./config/basic.json');
motionConfig.videodevice = projectConfig['webcam.device'];
motionConfig.on_event_start = "curl -X POST " + projectConfig['motionUrl'];

var config = MotionConfig({
    params: motionConfig
});
```

But in this case, the default config from 'motion' is used, because in config/index.js:36 "this.config" is undefined, which results in an empty "this.config".
Here is an example of _.assign with an undefined parameter: https://tonicdev.com/56a3faaa76ffc50d00b5b17a/56a3faaa76ffc50d00b5b17b

My simpe is to initialize this.config as an empty object.
